### PR TITLE
Fix incorrect error message in updateSourceTable helper

### DIFF
--- a/inngest/helpers.ts
+++ b/inngest/helpers.ts
@@ -133,7 +133,7 @@ export async function updateSourceTable(sourceId: string, status: Status, source
       data: { status, sourceTitle },
     });
   } catch (error) {
-    throw new VectorStoreError(`Failed to save to vector store: ${error}`);
+    throw new Error(`Failed to update source table status: ${error}`);
   }
 }
 


### PR DESCRIPTION
## Resolves #5

### Transformation Log
**File**: `inngest/helpers.ts`

#### Before (Lines 135-139)
```typescript
  } catch (error) {
    throw new VectorStoreError(`Failed to save to vector store: ${error}`); // <--- ERROR MESSAGE IS INCORRECT
  }
```

#### After (Lines 135-139)
```typescript
  } catch (error) {
    throw new Error(`Failed to update source table status: ${error}`);
  }
```

### Verification Results
Manual inspection confirms the error message now accurately reflects that the operation is updating the source table rather than saving to the vector store.


Closes #5