### PR TITLE
Fix race condition in credit reset logic

### DIFF
--- a/actions/credits.ts
+++ b/actions/credits.ts
@@ -45,23 +45,42 @@ export async function checkAndResetCredits(userId: string) {
  * @returns boolean - True if deduction was successful, false if insufficient credits.
  */
 export async function deductCredit(userId: string) {
-  const currentCredits = await checkAndResetCredits(userId);
+  // Use a transaction to perform the atomic reset and deduction
+  return await prisma.$transaction(async (tx) => {
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: { credits: true, lastCreditReset: true },
+    });
 
-  if (currentCredits === null || currentCredits <= 0) {
-    return false;
-  }
+    if (!user) return false;
 
-  const result = await prisma.user.updateMany({
-    where: {
-      id: userId,
-      credits: { gte: DEFAULT_CREDIT_DEDUCTION },
-    },
-    data: {
-      credits: { decrement: DEFAULT_CREDIT_DEDUCTION },
-    },
+    let credits = user.credits;
+    const lastReset = new Date(user.lastCreditReset).toDateString();
+    const today = new Date().toDateString();
+
+    if (lastReset !== today) {
+      credits = DEFAULT_CREDITS;
+    }
+
+    if (credits < DEFAULT_CREDIT_DEDUCTION) {
+      return false;
+    }
+
+    const updated = await tx.user.updateMany({
+      where: {
+        id: userId,
+        // Ensure that the state didn't change while we were reading
+        lastCreditReset: user.lastCreditReset,
+        credits: user.credits,
+      },
+      data: {
+        credits: credits - DEFAULT_CREDIT_DEDUCTION,
+        lastCreditReset: new Date(),
+      },
+    });
+
+    return updated.count > 0;
   });
-
-  return result.count > 0;
 }
 
 export async function getUserCredits(userId: string) {


### PR DESCRIPTION
## Resolves #14

### Transformation Log
**File**: `actions/credits.ts`

#### Before (Lines 47-84)
```typescript
export async function deductCredit(userId: string) {
  const currentCredits = await checkAndResetCredits(userId);

  if (currentCredits === null || currentCredits <= 0) {
    return false;
  }

  const result = await prisma.user.updateMany({
    where: {
      id: userId,
      credits: { gte: DEFAULT_CREDIT_DEDUCTION },
    },
    data: {
      credits: { decrement: DEFAULT_CREDIT_DEDUCTION },
    },
  });

  return result.count > 0;
}
```

#### After (Lines 47-84)
```typescript
export async function deductCredit(userId: string) {
  // Use a transaction to perform the atomic reset and deduction
  return await prisma.$transaction(async (tx) => {
    const user = await tx.user.findUnique({
      where: { id: userId },
      select: { credits: true, lastCreditReset: true },
    });

    if (!user) return false;

    let credits = user.credits;
    const lastReset = new Date(user.lastCreditReset).toDateString();
    const today = new Date().toDateString();

    if (lastReset !== today) {
      credits = DEFAULT_CREDITS;
    }

    if (credits < DEFAULT_CREDIT_DEDUCTION) {
      return false;
    }

    const updated = await tx.user.updateMany({
      where: {
        id: userId,
        // Ensure that the state didn't change while we were reading
        lastCreditReset: user.lastCreditReset,
        credits: user.credits,
      },
      data: {
        credits: credits - DEFAULT_CREDIT_DEDUCTION,
        lastCreditReset: new Date(),
      },
    });

    return updated.count > 0;
  });
}
```

### Verification Results
`pnpm run typecheck` passed successfully. The solution uses a Prisma transaction to ensure that the credit check and deduction are atomic, preventing the TOCTOU (Time-of-Check to Time-of-Use) race condition reported in the issue.

Closes #14