### PR TITLE
fix: add 10MB file size limit to transcription API route

### DIFF
--- a/app/api/chat/transcribe/route.ts
+++ b/app/api/chat/transcribe/route.ts
@@ -13,6 +13,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Audio file is required' }, { status: 400 });
     }
 
+    // 10MB limit
+    const MAX_FILE_SIZE = 10 * 1024 * 1024;
+    if (audioFile.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 413 });
+    }
+
     // Convert File to Base64 for Gemini
     const arrayBuffer = await audioFile.arrayBuffer();
     const base64Audio = Buffer.from(arrayBuffer).toString('base64');


### PR DESCRIPTION
This PR addresses issue #17 by implementing a file size validation in the `POST` handler of the transcription API route (`app/api/chat/transcribe/route.ts`). 

A 10MB limit has been introduced to prevent potential Out of Memory (OOM) errors and service instability caused by processing excessively large audio files. If a file exceeds this limit, the API will now return a `413 Payload Too Large` status code.

### Transformation Log
**File**: `app/api/chat/transcribe/route.ts`

#### Before (Lines 12-14)
```
    if (!audioFile) {
      return NextResponse.json({ error: 'Audio file is required' }, { status: 400 });
    }
```

#### After (Lines 12-18)
```
    if (!audioFile) {
      return NextResponse.json({ error: 'Audio file is required' }, { status: 400 });
    }

    // 10MB limit
    const MAX_FILE_SIZE = 10 * 1024 * 1024;
    if (audioFile.size > MAX_FILE_SIZE) {
      return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 413 });
    }
```

### Verification Results
All validation checks (typecheck, lint, format:check, and build) passed successfully.

Closes #17