### PR TITLE
Fix silent failure in generateCaptions

### DIFF
--- a/lib/llm/generate-captions.ts
+++ b/lib/llm/generate-captions.ts
@@ -12,33 +12,31 @@ export async function generateCaptions(
   const { deepgramKey } = config;
 
   if (!deepgramKey) {
-    console.error('[GENERATE_CAPTIONS_ERROR] Deepgram API key is missing');
-    return [];
+    throw new Error('Deepgram API key is missing');
   }
 
   // Deepgram SDK v5 uses the options object for initialization
   const deepgram = new DeepgramClient({ apiKey: deepgramKey });
 
-  try {
-    // Deepgram SDK v5 method path for remote URL transcription.
-    // We cast the options object to 'any' to resolve the TypeScript error:
-    // "Object literal may only specify known properties, and 'model' does not exist in type 'RequestOptions'".
-    const response = await deepgram.listen.v1.media.transcribeUrl({ url: audioUrl }, {
-      model: TRANSCRIPTION_MODEL_ID, // nova-3
-      smart_format: true,
-      punctuate: true,
-      keyterm: keyterms,
-    } as any);
+  // Deepgram SDK v5 method path for remote URL transcription.
+  // We cast the options object to 'any' to resolve the TypeScript error:
+  // "Object literal may only specify known properties, and 'model' does not exist in type 'RequestOptions'".
+  const response = await deepgram.listen.v1.media.transcribeUrl({ url: audioUrl }, {
+    model: TRANSCRIPTION_MODEL_ID, // nova-3
+    smart_format: true,
+    punctuate: true,
+    keyterm: keyterms,
+  } as any);
 
-    // Deepgram SDK v5 returns a union type that might be an 'Accepted' response (for callbacks).
-    // Since we are using it synchronously, we cast to 'any' to access the 'results' property safely.
-    // We also handle both 'response.results' and 'response.result.results' patterns seen in different v5 sub-versions.
-    const res = response as any;
-    const results = res.results || res.result?.results;
+  // Deepgram SDK v5 returns a union type that might be an 'Accepted' response (for callbacks).
+  // Since we are using it synchronously, we cast to 'any' to access the 'results' property safely.
+  // We also handle both 'response.results' and 'response.result.results' patterns seen in different v5 sub-versions.
+  const res = response as any;
+  const results = res.results || res.result?.results;
 
-    return results?.channels[0]?.alternatives[0]?.words || [];
-  } catch (error) {
-    console.error('[GENERATE_CAPTIONS_ERROR]', error);
-    return [];
+  if (!results) {
+    throw new Error('Failed to retrieve transcription results from Deepgram');
   }
+
+  return results.channels[0]?.alternatives[0]?.words || [];
 }


### PR DESCRIPTION
This PR addresses issue #16 by modifying the `generateCaptions` function to properly propagate errors instead of silently failing and returning an empty array.

- Changed `generateCaptions` to throw an error if the API key is missing.
- Changed `generateCaptions` to throw an error if no results are returned from the Deepgram API.
- Removed the broad `try...catch` block that was masking errors.

This allows callers to handle failures appropriately, improving debuggability and user experience.

Closes #16