### PR TITLE
Fix path traversal vulnerability in S3 presigned upload endpoint

### DIFF
--- a/app/api/s3/presigned-upload/route.ts
+++ b/app/api/s3/presigned-upload/route.ts
@@ -17,11 +17,27 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Missing contentType or customPath' }, { status: 400 });
     }
 
+    // Authentication: Get the current user session
+    const { auth } = await import('@/lib/auth');
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userId = session.user.id;
+
     // Use customPath if provided, otherwise generate a unique one
     let path = customPath;
     if (!path) {
       const fileExtension = contentType?.split('/')[1] || 'bin';
       path = `${folder}/${uuidv4()}.${fileExtension}`;
+    } else {
+      // Security: Sanitize path and enforce prefix
+      const sanitizedPath = customPath.replace(/\.\.\//g, '').replace(/^\/+/, '');
+      path = `users/${userId}/${sanitizedPath}`;
     }
 
     const uploadUrl = await getPresignedUploadUrl(path, contentType || 'application/octet-stream');


### PR DESCRIPTION
This PR addresses the security vulnerability where a path traversal attack was possible via the `customPath` parameter in the `app/api/s3/presigned-upload/route.ts` endpoint.

Changes:
1. Added authentication check using `better-auth` to ensure only logged-in users can request a presigned upload URL.
2. Sanitized `customPath` by removing path traversal characters (`..`).
3. Enforced a strict path prefix `users/${userId}/` to ensure files are confined to the user's personal storage space.

Verified with typecheck, lint, format, and build.

Closes #20